### PR TITLE
[Relationships] Add empty-to-one relationships when entity property is null and filter only not-loaded relationships

### DIFF
--- a/lib/jsonapi/relationships/not_loaded.ex
+++ b/lib/jsonapi/relationships/not_loaded.ex
@@ -1,0 +1,5 @@
+defmodule JSONAPI.Relationships.NotLoaded do
+  @moduledoc false
+
+  defstruct []
+end

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -153,11 +153,13 @@ defmodule JSONAPI.Serializer do
 
   @spec encode_relation(tuple()) :: map()
   def encode_relation({rel_view, rel_data, _rel_url, _conn} = info) do
-    data = %{
-      data: encode_rel_data(rel_view, rel_data)
-    }
+    case encode_rel_data(rel_view, rel_data) do
+      nil ->
+        nil
 
-    merge_related_links(data, info, remove_links?())
+      rel_data ->
+        merge_related_links(%{data: rel_data}, info, remove_links?())
+    end
   end
 
   defp merge_base_links(%{links: links} = doc, data, view, conn) do
@@ -219,6 +221,7 @@ defmodule JSONAPI.Serializer do
 
   defp assoc_loaded?(nil), do: false
   defp assoc_loaded?(%{__struct__: Ecto.Association.NotLoaded}), do: false
+  defp assoc_loaded?(%JSONAPI.Relationships.NotLoaded{}), do: false
   defp assoc_loaded?(_association), do: true
 
   defp get_includes(view, query_includes) do

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -219,7 +219,6 @@ defmodule JSONAPI.Serializer do
     |> Enum.uniq()
   end
 
-  defp assoc_loaded?(nil), do: false
   defp assoc_loaded?(%{__struct__: Ecto.Association.NotLoaded}), do: false
   defp assoc_loaded?(%JSONAPI.Relationships.NotLoaded{}), do: false
   defp assoc_loaded?(_association), do: true

--- a/test/jsonapi/serializer_test.exs
+++ b/test/jsonapi/serializer_test.exs
@@ -297,9 +297,22 @@ defmodule JSONAPI.SerializerTest do
     assert attributes[:body] == data[:body]
 
     assert encoded_data[:links][:self] == PostView.url_for(data, nil)
-    assert map_size(encoded_data[:relationships]) == 1
+    assert map_size(encoded_data[:relationships]) == 2
 
     assert Enum.count(encoded[:included]) == 1
+  end
+
+  test "serialize handles an unloaded relationship" do
+    data = %{
+      id: 1,
+      text: "Hello",
+      body: "Hello world",
+      author: %{id: 2, username: "jason"},
+      best_comments: %JSONAPI.Relationships.NotLoaded{}
+    }
+
+    encoded = Serializer.serialize(PostView, data, nil)
+    assert map_size(encoded[:data][:relationships]) == 1
   end
 
   test "serialize handles a relationship self link on a show request" do


### PR DESCRIPTION
In order to have a [JSON:API compliant](https://jsonapi.org/format/#document-resource-object-linkage) empty-to-one relationship, an entity property representing a relationship should be null; the library, however, treats null as a "not loaded" value, making impossible to have such a type of relationship.

This PR fixes the behavior, also introducing a JSONAPI NotLoaded placeholder in order not to necessarily depend on Ecto